### PR TITLE
Readme updates to reflect file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Code Llama and Code Llama - Instruct 7B and 13B models are capable of filling in
 
 See `example_infilling.py` for some examples. The `CodeLlama-7b` model can be run for infilling with the command below (`nproc_per_node` needs to be set to the `MP` value):
 ```
-torchrun --nproc_per_node 1 example_text_infilling.py \
+torchrun --nproc_per_node 1 example_infilling.py \
     --ckpt_dir CodeLlama-7b/ \
     --tokenizer_path CodeLlama-7b/tokenizer.model \
     --max_seq_len 192 --max_batch_size 4

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The Code Llama and Code Llama - Python models are not fine-tuned to follow instr
 See `example_completion.py` for some examples. To illustrate, see command below to run it with the `CodeLlama-7b` model (`nproc_per_node` needs to be set to the `MP` value):
 
 ```
-torchrun --nproc_per_node 1 example_code_completion.py \
+torchrun --nproc_per_node 1 example_completion.py \
     --ckpt_dir CodeLlama-7b/ \
     --tokenizer_path CodeLlama-7b/tokenizer.model \
     --max_seq_len 128 --max_batch_size 4


### PR DESCRIPTION
I noticed that `example_code_completion.py` doesn't exist in this repo, but `example_completion.py` does, same with `example_code_infilling.py`