### PR TITLE
Enable parallelism by adding parameter pipeline_length to Llama.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,59 @@ Fine-tuned instruction-following models are: the Code Llama - Instruct models `C
 Code Llama is a new technology that carries potential risks with use. Testing conducted to date has not — and could not — cover all scenarios.
 In order to help developers address these risks, we have created the [Responsible Use Guide](https://github.com/facebookresearch/llama/blob/main/Responsible-Use-Guide.pdf). More details can be found in our research papers as well.
 
+### Parallelization
+
+CodeLLama is built on top of [FairScale](https://github.com/facebookresearch/fairscale), a PyTorch extension library that extends and new SOTA scaling techniques.
+As explained in [Inference section](#Inference), CodeLlama requires model-parallelization (MP) for CodeLlama-13B and CodeLlama-34B.
+CodeLlama also supports other parallelization mechanisms provided by FairScale, notably, [Pipeline Parallelism (PP)](https://fairscale.readthedocs.io/en/latest/deep_dive/pipeline_parallelism.html) and Distributed Data Parallelism (DDP).
+
+
+
+#### Pipeline parallelism (PP)
+
+Examples using `CodeLlama-7b-Instruct` on two GPUs using PP:
+```
+torchrun --nproc_per_node 2 example_instructions.py \
+    --ckpt_dir CodeLlama-7b-Instruct/ \
+    --tokenizer_path CodeLlama-7b-Instruct/tokenizer.model \
+    --max_seq_len 512 --max_batch_size 4 --pipeline_length 2
+```
+
+#### Distributed Data Parallelism (DDP)
+
+DDP is executed automatically when the number of GPUs available (indicated via `--nproc_per_node`) is larger than the GPUs required by the model (see [Inference section](#Inference)).
+
+Example using `CodeLlama-7b-Instruct` on two GPUs using DDP:
+
+```
+torchrun --nproc_per_node 2 example_instructions.py \
+    --ckpt_dir CodeLlama-7b-Instruct/ \
+    --tokenizer_path CodeLlama-7b-Instruct/tokenizer.model \
+    --max_seq_len 512 --max_batch_size 4
+```
+
+FairScale computes the length of the data parallelism as follows:
+
+```
+data_parallel_size = #GPUs / (model_parallel_size * pipeline_length))
+```
+
+By default, `pipeline_length` is 1 (i.e., PP is disable).
+
+
+#### Combining DDP and PP Parallelism
+
+Example using `CodeLlama-7b-Instruct` on four GPUs using DDP and PP:
+
+```
+torchrun --nproc_per_node 4 example_instructions.py \
+    --ckpt_dir CodeLlama-7b-Instruct/ \
+    --tokenizer_path CodeLlama-7b-Instruct/tokenizer.model \
+    --max_seq_len 512 --max_batch_size 4 --pipeline_length 2
+```
+
+
+
 ## Issues
 Please report any software “bug”, or other problems with the models through one of the following means:
 - Reporting issues with the model: [github.com/facebookresearch/codellama](http://github.com/facebookresearch/codellama)

--- a/example_instructions.py
+++ b/example_instructions.py
@@ -16,12 +16,16 @@ def main(
     max_seq_len: int = 512,
     max_batch_size: int = 8,
     max_gen_len: Optional[int] = None,
+    model_parallel_size:  Optional[int] = None,
+    pipeline_length: int = 1
 ):
     generator = Llama.build(
         ckpt_dir=ckpt_dir,
         tokenizer_path=tokenizer_path,
         max_seq_len=max_seq_len,
         max_batch_size=max_batch_size,
+        model_parallel_size= model_parallel_size,
+        pipeline_length=  pipeline_length
     )
 
     instructions = [


### PR DESCRIPTION
The parameter pipeline_length, which is added to the Llama.build (generation.py),  is then passed to the initialize_model_parallel (from FairScale) to control the parallelization (Model Parallel, Pipeline Parallel, and/or Distributed Data Parallel).

Also update one of the examples (example_intructions.py) and the README.