### PR TITLE
Bugfixing error thrown when logprobs=True

### DIFF
--- a/llama/generation.py
+++ b/llama/generation.py
@@ -229,7 +229,7 @@ class Llama:
             return [
                 {
                     "generation": self.tokenizer.decode(t),
-                    "tokens": [self.tokenizer.decode(x) for x in t],
+                    "tokens": t,
                     "logprobs": logprobs_i,
                 }
                 for t, logprobs_i in zip(generation_tokens, generation_logprobs)
@@ -364,7 +364,7 @@ class Llama:
                         if not unsafe
                         else UNSAFE_ERROR,
                     },
-                    "tokens": [self.tokenizer.decode(x) for x in t],
+                    "tokens": t,
                     "logprobs": logprobs_i,
                 }
                 for t, logprobs_i, unsafe in zip(


### PR DESCRIPTION
This PR introduces a fix for the error: "TypeError: 'int' object is not iterable" that appears when one invokes to text_completion or chat_completion  method with argument logprobs=True. For example, 

```
    results = generator.chat_completion(
        instructions,  
        max_gen_len=max_gen_len,
        temperature=temperature,
        top_p=top_p,
        logprobs=True ## Exposes the wrong behaviour
    )
```
or 

```
    results = generator.text_completion(
        prompts,
        max_gen_len=max_gen_len,
        temperature=temperature,
        top_p=top_p,
        logprobs=True ## Exposes the wrong behaviour

    )
```

The changes done by this PR fixes this problem.