### PR TITLE
chore(deps): Update dependencies

### DIFF
--- a/.circleci/config.yaml
+++ b/.circleci/config.yaml
@@ -3,41 +3,47 @@ version: 2.1
 jobs:
   check_python_format:
     docker:
-      - image: circleci/python:3.9
-    steps:
-      - checkout
-      - run:
-          name: "Check format of .py with ufmt"
-          command: |
-            pip install black==22.12.0
-            pip install usort==1.0.5
-            pip install ufmt==2.0.1
-            ufmt check .
-  check_type_annotation:
-    docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.12
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+            - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}-{{ checksum "ci-requirements.txt" }}
+      - run:
+          name: "Check format of .py with ufmt"
+          command: |
+            python3 -m venv venv
+            source venv/bin/activate
+            pip install -r ci-requirements.txt
+            ufmt check .
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}-{{ checksum "ci-requirements.txt" }}
+  check_type_annotation:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}-{{ checksum "ci-requirements.txt" }}
       - run:
           name: install dependencies
           command: |
             python3 -m venv venv
-            . venv/bin/activate
-            pip install -r requirements.txt
-            pip install -r dev-requirements.txt
+            source venv/bin/activate
+            pip install -r requirements.txt -r dev-requirements.txt
       - run:
           name: "mypy"
           command: |
-            . venv/bin/activate
+            source venv/bin/activate
             mkdir .mypy_cache
             mypy --install-types --non-interactive ./ --cache-dir=.mypy_cache/
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}-{{ checksum "ci-requirements.txt" }}
 
 workflows:
   frontend:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily" # Update pip dependencies daily

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,0 +1,3 @@
+black==24.4.2
+usort==1.0.8.post1
+ufmt==2.5.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-black==22.12.0
-usort==1.0.5
-ufmt==2.0.1
-mypy==1.3.0
+-r ci-requirements.txt
+mypy==1.10.0
+setuptools==69.5.1

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This software may be used and distributed according to the terms of the Llama 2 Community License Agreement.
 
+from pkg_resources import parse_requirements
 from setuptools import find_packages, setup
 
 
 def get_requirements(path: str):
-    return [l.strip() for l in open(path)]
+    with open(path) as requirements:
+        return [r.project_name for r in parse_requirements(requirements)]
 
 
 setup(


### PR DESCRIPTION
Updated:
* Dev dependencies
* Python 3.9 to 3.12 

Changes:
* Deduplicate dev dependencies in CI
* Cache venv in all CI jobs
* Improve setup.py and CI
* Let Dependabot update pip/poetry dependencies