### PR TITLE
Fix dimension error in annotate.

### DIFF
--- a/llama/model.py
+++ b/llama/model.py
@@ -179,8 +179,8 @@ class Attention(nn.Module):
         values = self.cache_v[:bsz, : start_pos + seqlen]
 
         # repeat k/v heads if n_kv_heads < n_heads
-        keys = repeat_kv(keys, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
-        values = repeat_kv(values, self.n_rep)  # (bs, seqlen, n_local_heads, head_dim)
+        keys = repeat_kv(keys, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
+        values = repeat_kv(values, self.n_rep)  # (bs, cache_len + seqlen, n_local_heads, head_dim)
 
         xq = xq.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
         keys = keys.transpose(1, 2)


### PR DESCRIPTION
After reading kv_cache, keys and values should have the dimensions of (bs, cache_len + seqlen, n_local_heads, head_dim), rather than (bs, seqlen, n_local_heads, head_dim).